### PR TITLE
Update item memorization

### DIFF
--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -22,6 +22,7 @@ repositories {
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-web")
+	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0")
 	implementation("mysql:mysql-connector-java:8.0.33")

--- a/server/src/main/kotlin/com/laev/reminder/controller/ItemController.kt
+++ b/server/src/main/kotlin/com/laev/reminder/controller/ItemController.kt
@@ -2,19 +2,17 @@ package com.laev.reminder.controller
 
 import com.laev.reminder.dto.AddItemRequest
 import com.laev.reminder.dto.GetItemsResponse
+import com.laev.reminder.dto.UpdateMemorizationRequest
+import com.laev.reminder.exception.ItemNotFoundException
 import com.laev.reminder.service.ItemService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import jakarta.validation.Valid
+import jakarta.validation.constraints.NotNull
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import java.time.OffsetDateTime
 
 @RestController
@@ -57,10 +55,25 @@ class ItemController(
     @PostMapping
     @Operation(summary = "Add an item")
     fun addItem(
-        @Valid @RequestBody request: AddItemRequest,
+        @RequestBody @Valid request: AddItemRequest,
     ): ResponseEntity<Void> {
         itemService.addItem(request)
 
         return ResponseEntity.status(HttpStatus.CREATED).build()
+    }
+
+    @PatchMapping("/{id}/memorization")
+    @Operation(summary = "Mark an item as memorized or not")
+    fun updateMemorization(
+        @RequestBody @Valid request: UpdateMemorizationRequest,
+        @PathVariable @NotNull(message = "ID cannot be null") id: Long,
+    ): ResponseEntity<String?> {
+        try {
+            itemService.updateMemorization(id, request.isMemorized!!, request.offset)
+        } catch (e: ItemNotFoundException) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.message)
+        }
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
     }
 }

--- a/server/src/main/kotlin/com/laev/reminder/controller/ItemController.kt
+++ b/server/src/main/kotlin/com/laev/reminder/controller/ItemController.kt
@@ -36,13 +36,14 @@ class ItemController(
             .headers(responseHeaders)
             .body(
                 items.map { item ->
+                    val count = itemService.getItemMemorizationCount(item.id!!)
                     GetItemsResponse(
                         id = item.id ?: 0,
                         mainText = item.mainText,
                         subText = item.subText,
                         createdDatetime = item.createdDatetime,
-                        successCount = item.successCount,
-                        failCount = item.failCount,
+                        successCount = count.successCount,
+                        failCount = count.failCount,
                         isRecurring = item.isRecurring,
                         reviewDates = item.reviewDates
                             .removePrefix("[").removeSuffix("]")

--- a/server/src/main/kotlin/com/laev/reminder/dto/GetItemsResponse.kt
+++ b/server/src/main/kotlin/com/laev/reminder/dto/GetItemsResponse.kt
@@ -17,10 +17,10 @@ class GetItemsResponse(
     val createdDatetime: OffsetDateTime,
 
     @Schema(description = "Number of successful attempts", example = "0")
-    val successCount: Short,
+    val successCount: Int,
 
     @Schema(description = "Number of failed attempts", example = "0")
-    val failCount: Short,
+    val failCount: Int,
 
     @Schema(description = "Flag indicating if the item is exposed repeatedly", example = "true")
     @get:JsonProperty("isRecurring")

--- a/server/src/main/kotlin/com/laev/reminder/dto/GetItemsResponse.kt
+++ b/server/src/main/kotlin/com/laev/reminder/dto/GetItemsResponse.kt
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import java.time.OffsetDateTime
 
 class GetItemsResponse(
-    val id: Int,
+    val id: Long,
 
     @Schema(example = "Banana")
     val mainText: String,

--- a/server/src/main/kotlin/com/laev/reminder/dto/UpdateMemorizationRequest.kt
+++ b/server/src/main/kotlin/com/laev/reminder/dto/UpdateMemorizationRequest.kt
@@ -1,0 +1,15 @@
+package com.laev.reminder.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotNull
+import java.time.ZoneOffset
+
+class UpdateMemorizationRequest(
+    @field:NotNull(message = "'isMemorized' field is required")
+    @Schema(nullable = false)
+    val isMemorized: Boolean?, // If declared as non-nullable, it defaults to false during deserialization instead of triggering validation for null values.
+
+    @field:NotNull(message = "'offset' field is required")
+    @Schema(example = "-05:00", nullable = false)
+    val offset: ZoneOffset,
+)

--- a/server/src/main/kotlin/com/laev/reminder/entity/Item.kt
+++ b/server/src/main/kotlin/com/laev/reminder/entity/Item.kt
@@ -20,12 +20,6 @@ class Item(
     val createdDatetime: OffsetDateTime = OffsetDateTime.now(ZoneOffset.UTC),
 
     @Column
-    val successCount: Short = 0,
-
-    @Column
-    val failCount: Short = 0,
-
-    @Column
     val isRecurring: Boolean = true,
 
     @Column

--- a/server/src/main/kotlin/com/laev/reminder/entity/Item.kt
+++ b/server/src/main/kotlin/com/laev/reminder/entity/Item.kt
@@ -8,7 +8,7 @@ import java.time.ZoneOffset
 class Item(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    var id: Int? = null,
+    var id: Long? = null,
 
     @Column(nullable = false)
     val mainText: String,

--- a/server/src/main/kotlin/com/laev/reminder/entity/Member.kt
+++ b/server/src/main/kotlin/com/laev/reminder/entity/Member.kt
@@ -10,7 +10,7 @@ import jakarta.persistence.Id
 class Member(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    var id: Int? = null,
+    var id: Long? = null,
 
     @Column
     val name: String,

--- a/server/src/main/kotlin/com/laev/reminder/entity/Member.kt
+++ b/server/src/main/kotlin/com/laev/reminder/entity/Member.kt
@@ -13,5 +13,11 @@ class Member(
     var id: Long? = null,
 
     @Column
+    val email: String,
+
+    @Column
+    val password: String,
+
+    @Column
     val name: String,
 )

--- a/server/src/main/kotlin/com/laev/reminder/entity/MemorizationLog.kt
+++ b/server/src/main/kotlin/com/laev/reminder/entity/MemorizationLog.kt
@@ -1,0 +1,21 @@
+package com.laev.reminder.entity
+
+import jakarta.persistence.*
+import java.time.OffsetDateTime
+
+@Entity
+class MemorizationLog(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @Column(nullable = false)
+    val isMemorized: Boolean,
+
+    @Column(nullable = false)
+    val createdDatetime: OffsetDateTime,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id", nullable = false)
+    val item: Item,
+)

--- a/server/src/main/kotlin/com/laev/reminder/entity/ReviewDatetime.kt
+++ b/server/src/main/kotlin/com/laev/reminder/entity/ReviewDatetime.kt
@@ -7,7 +7,7 @@ import java.time.OffsetDateTime
 class ReviewDatetime(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    var id: Int? = null,
+    var id: Long? = null,
 
     @Column(nullable = false)
     val start: OffsetDateTime,

--- a/server/src/main/kotlin/com/laev/reminder/exception/GlobalExceptionHandler.kt
+++ b/server/src/main/kotlin/com/laev/reminder/exception/GlobalExceptionHandler.kt
@@ -1,0 +1,17 @@
+package com.laev.reminder.exception
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+    @ExceptionHandler(HttpMessageNotReadableException::class)
+    fun handleInvalidFormatException(ex: HttpMessageNotReadableException): ResponseEntity<Map<String, String>> {
+        val errorMessage = ex.cause?.message ?: "Invalid request body"
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(mapOf("error" to errorMessage))
+    }
+}

--- a/server/src/main/kotlin/com/laev/reminder/exception/ItemNotFoundException.kt
+++ b/server/src/main/kotlin/com/laev/reminder/exception/ItemNotFoundException.kt
@@ -1,0 +1,3 @@
+package com.laev.reminder.exception
+
+class ItemNotFoundException(itemId: Long): RuntimeException("Item with ID $itemId not found")

--- a/server/src/main/kotlin/com/laev/reminder/repository/MemorizationLogRepository.kt
+++ b/server/src/main/kotlin/com/laev/reminder/repository/MemorizationLogRepository.kt
@@ -1,8 +1,20 @@
 package com.laev.reminder.repository
 
 import com.laev.reminder.entity.MemorizationLog
+import com.laev.reminder.service.dto.ItemMemorizationCount
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 
 @Repository
-interface MemorizationLogRepository: JpaRepository<MemorizationLog, Long>
+interface MemorizationLogRepository: JpaRepository<MemorizationLog, Long> {
+    @Query("""
+        select new com.laev.reminder.service.dto.ItemMemorizationCount(
+                cast(coalesce(sum(case when m.isMemorized = true then 1 else 0 end), 0) as int),
+                cast(coalesce(sum(case when m.isMemorized = false then 1 else 0 end), 0) as int)
+            )
+        from MemorizationLog m 
+        where m.item.id = :itemId
+    """)
+    fun findMemorizationCountsByItemId(itemId: Long): ItemMemorizationCount
+}

--- a/server/src/main/kotlin/com/laev/reminder/repository/MemorizationLogRepository.kt
+++ b/server/src/main/kotlin/com/laev/reminder/repository/MemorizationLogRepository.kt
@@ -1,0 +1,8 @@
+package com.laev.reminder.repository
+
+import com.laev.reminder.entity.MemorizationLog
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface MemorizationLogRepository: JpaRepository<MemorizationLog, Long>

--- a/server/src/main/kotlin/com/laev/reminder/repository/ReviewDatetimeRepository.kt
+++ b/server/src/main/kotlin/com/laev/reminder/repository/ReviewDatetimeRepository.kt
@@ -8,9 +8,9 @@ import java.time.OffsetDateTime
 
 @Repository
 interface ReviewDatetimeRepository: JpaRepository<ReviewDatetime, Long> {
-    @Query("SELECT r FROM ReviewDatetime r WHERE r.start <= :datetime AND :datetime < r.end")
+    @Query("select r from ReviewDatetime r where r.start <= :datetime and :datetime < r.end")
     fun findByDatetimeRange(datetime: OffsetDateTime): List<ReviewDatetime>
 
-    @Query("SELECT r FROM ReviewDatetime r WHERE r.start = :startDatetime AND r.item.id = :itemId")
+    @Query("select r from ReviewDatetime r where r.start = :startDatetime and r.item.id = :itemId")
     fun findByStartAndItemId(startDatetime: OffsetDateTime, itemId: Long): List<ReviewDatetime>
 }

--- a/server/src/main/kotlin/com/laev/reminder/repository/ReviewDatetimeRepository.kt
+++ b/server/src/main/kotlin/com/laev/reminder/repository/ReviewDatetimeRepository.kt
@@ -10,4 +10,7 @@ import java.time.OffsetDateTime
 interface ReviewDatetimeRepository: JpaRepository<ReviewDatetime, Long> {
     @Query("SELECT r FROM ReviewDatetime r WHERE r.start <= :datetime AND :datetime < r.end")
     fun findByDatetimeRange(datetime: OffsetDateTime): List<ReviewDatetime>
+
+    @Query("SELECT r FROM ReviewDatetime r WHERE r.start = :startDatetime AND r.item.id = :itemId")
+    fun findByStartAndItemId(startDatetime: OffsetDateTime, itemId: Long): List<ReviewDatetime>
 }

--- a/server/src/main/kotlin/com/laev/reminder/service/ItemService.kt
+++ b/server/src/main/kotlin/com/laev/reminder/service/ItemService.kt
@@ -10,6 +10,7 @@ import com.laev.reminder.exception.ItemNotFoundException
 import com.laev.reminder.repository.ItemRepository
 import com.laev.reminder.repository.MemorizationLogRepository
 import com.laev.reminder.repository.ReviewDatetimeRepository
+import com.laev.reminder.service.dto.ItemMemorizationCount
 import com.laev.reminder.utils.CycleCalculator
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
@@ -32,6 +33,10 @@ class ItemService(
         val reviewDatetimes = reviewDatetimeRepository.findByDatetimeRange(datetime)
 
         return reviewDatetimes.map { it.item }
+    }
+
+    fun getItemMemorizationCount(itemId: Long): ItemMemorizationCount {
+        return memorizationLogRepository.findMemorizationCountsByItemId(itemId)
     }
 
     @Transactional

--- a/server/src/main/kotlin/com/laev/reminder/service/ItemService.kt
+++ b/server/src/main/kotlin/com/laev/reminder/service/ItemService.kt
@@ -42,7 +42,7 @@ class ItemService(
     @Transactional
     fun addItem(request: AddItemRequest) {
         try {
-            val member = Member(1, "Lyla") // TODO
+            val member = Member(1, "test@test.com", "0000", "Lyla") // TODO
             val createDatetime = OffsetDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS) // save time in UTC
             val cycles = listOf(1, 3, 7, 21)
             val reviewDates = CycleCalculator.getReviewDates(createDatetime, cycles)

--- a/server/src/main/kotlin/com/laev/reminder/service/dto/ItemMemorizationCount.kt
+++ b/server/src/main/kotlin/com/laev/reminder/service/dto/ItemMemorizationCount.kt
@@ -1,0 +1,6 @@
+package com.laev.reminder.service.dto
+
+class ItemMemorizationCount(
+    val successCount: Int,
+    val failCount: Int,
+)


### PR DESCRIPTION
- built PATCH `/{id}/memorization`
  - create memorization log
  - if not memorized, add a new review date for tomorrow
  - respond with 404 error when requested ID doesn't exist

- deleted success_count, fail_count in Item table
  - Instead, count item memorization log by query

- add new columns in Member entity due to DB spec modification